### PR TITLE
Added support for --on-release option on external Python Sender client

### DIFF
--- a/messaging_components/clients/external/python/command/python_commands.py
+++ b/messaging_components/clients/external/python/command/python_commands.py
@@ -5,7 +5,8 @@ Implementation of cli-proton-python external client command.
 from messaging_components.clients.external.command.client_command import ConnectorClientCommand, ReceiverClientCommand, \
     LinkOptionsReceiver, ReactorOptionsSenderReceiver, SenderClientCommand, LinkOptionsSenderReceiver
 from messaging_components.clients.external.python.command.python_options import PythonControlOptionsCommon, \
-    PythonControlOptionsReceiver, PythonControlOptionsSenderReceiver, PythonConnectionOptionsCommon
+    PythonControlOptionsReceiver, PythonControlOptionsSenderReceiver, PythonConnectionOptionsCommon, \
+    PythonControlOptionsSender
 
 
 class PythonConnectorClientCommand(ConnectorClientCommand):
@@ -51,7 +52,7 @@ class PythonSenderClientCommand(SenderClientCommand):
     def __init__(self, stdout: bool=False, stderr: bool=False, daemon: bool=False,
                  timeout: int=0, encoding: str="utf-8"):
         super(PythonSenderClientCommand, self).__init__(stdout, stderr, daemon, timeout, encoding)
-        self.control = PythonControlOptionsSenderReceiver()
+        self.control = PythonControlOptionsSender()
         self.link = LinkOptionsSenderReceiver()
         self.reactor = ReactorOptionsSenderReceiver()
         self.connection = PythonConnectionOptionsCommon()

--- a/messaging_components/clients/external/python/command/python_options.py
+++ b/messaging_components/clients/external/python/command/python_options.py
@@ -44,8 +44,26 @@ class PythonControlOptionsReceiver(ControlOptionsReceiver, PythonControlOptionsS
                  duration_mode: str=None, capacity: int=None, dynamic: bool=False):
         ControlOptionsReceiver.__init__(self, dynamic=dynamic)
         PythonControlOptionsSenderReceiver.__init__(self, broker_url=broker_url, count=count,
-                                                  timeout=timeout, sync_mode=sync_mode, duration=duration,
-                                                  duration_mode=duration_mode, capacity=capacity)
+                                                    timeout=timeout, sync_mode=sync_mode, duration=duration,
+                                                    duration_mode=duration_mode, capacity=capacity)
+
+
+class PythonControlOptionsSender(PythonControlOptionsSenderReceiver):
+    """
+    Specialized implementation of control options for Sender Python client command.
+    """
+    def __init__(self, broker_url: str='127.0.0.1:5672/examples', count: int=1,
+                 timeout: int=None, sync_mode: str=None, duration: int=None,
+                 duration_mode: str=None, capacity: int=None, on_release: str='retry'):
+        PythonControlOptionsSenderReceiver.__init__(self, broker_url=broker_url, count=count,
+                                                    timeout=timeout, sync_mode=sync_mode, duration=duration,
+                                                    duration_mode=duration_mode, capacity=capacity)
+        self.on_release = on_release
+
+    def valid_options(self) -> list:
+        return PythonControlOptionsCommon.valid_options(self) + [
+            Prefixed('on-release', '--on-release')
+        ]
 
 
 class PythonConnectionOptionsCommon(ConnectionOptionsCommon):


### PR DESCRIPTION
@enkeys just to keep you updated. I am going to merge it. I was able to test locally and seems to be ok.